### PR TITLE
Add MySQL user CRUD operations functionality

### DIFF
--- a/ProxysqlAdminUi.Web/Components/Pages/MySql/Users/AddMysqlUserDialog.razor
+++ b/ProxysqlAdminUi.Web/Components/Pages/MySql/Users/AddMysqlUserDialog.razor
@@ -1,0 +1,217 @@
+@using ProxysqlAdminUi.Web.Models
+@using ProxysqlAdminUi.Web.Repositories
+
+@attribute [Authorize]
+
+@inject ProxySqlRepository ProxySqlRepository
+@inject DialogService DialogService
+@inject NotificationService NotificationService
+
+<RadzenContent Container="main">
+    <RadzenStack Gap="1rem">
+        @if (_mysqlUser != null)
+        {
+            <RadzenTemplateForm TItem="MysqlUserModel" Data=@_mysqlUser Submit=@OnSubmit>
+                <RadzenCard>
+                    <RadzenStack Gap="1rem">
+                        <!-- Basic Properties -->
+                        <RadzenRow>
+                            <RadzenColumn Size="12">
+                                <RadzenStack>
+                                    <RadzenLabel Text="Username" />
+                                    <RadzenTextBox @bind-Value=@_mysqlUser.Username Name="@nameof(MysqlUserModel.Username)" />
+                                    <RadzenRequiredValidator Component="@nameof(MysqlUserModel.Username)" Text="Username is required" />
+                                </RadzenStack>
+                            </RadzenColumn>
+                        </RadzenRow>
+
+                        <RadzenRow>
+                            <RadzenColumn Size="12">
+                                <RadzenStack>
+                                    <RadzenLabel Text="Password" />
+                                    <RadzenPassword @bind-Value=@_mysqlUser.Password Name="@nameof(MysqlUserModel.Password)" />
+                                </RadzenStack>
+                            </RadzenColumn>
+                        </RadzenRow>
+
+                        <RadzenRow>
+                            <RadzenColumn Size="6">
+                                <RadzenStack>
+                                    <RadzenLabel Text="Default Hostgroup" />
+                                    <RadzenNumeric @bind-Value=@_mysqlUser.DefaultHostgroup Name="@nameof(MysqlUserModel.DefaultHostgroup)" Min="0" />
+                                </RadzenStack>
+                            </RadzenColumn>
+                            <RadzenColumn Size="6">
+                                <RadzenStack>
+                                    <RadzenLabel Text="Max Connections" />
+                                    <RadzenNumeric @bind-Value=@_mysqlUser.MaxConnections Name="@nameof(MysqlUserModel.MaxConnections)" Min="0" />
+                                </RadzenStack>
+                            </RadzenColumn>
+                        </RadzenRow>
+
+                        <RadzenRow>
+                            <RadzenColumn Size="12">
+                                <RadzenStack>
+                                    <RadzenLabel Text="Default Schema" />
+                                    <RadzenTextBox @bind-Value=@_mysqlUser.DefaultSchema Name="@nameof(MysqlUserModel.DefaultSchema)" />
+                                </RadzenStack>
+                            </RadzenColumn>
+                        </RadzenRow>
+
+                        <RadzenRow>
+                            <RadzenColumn Size="4">
+                                <RadzenStack Orientation="Orientation.Horizontal" AlignItems="AlignItems.Center" Gap="0.5rem">
+                                    <RadzenCheckBox @bind-Value=@_activeChecked Name="Active" />
+                                    <RadzenLabel Text="Active" Component="Active" />
+                                </RadzenStack>
+                            </RadzenColumn>
+                            <RadzenColumn Size="4">
+                                <RadzenStack Orientation="Orientation.Horizontal" AlignItems="AlignItems.Center" Gap="0.5rem">
+                                    <RadzenCheckBox @bind-Value=@_useSslChecked Name="UseSsl" />
+                                    <RadzenLabel Text="Use SSL" Component="UseSsl" />
+                                </RadzenStack>
+                            </RadzenColumn>
+                            <RadzenColumn Size="4">
+                                <RadzenStack Orientation="Orientation.Horizontal" AlignItems="AlignItems.Center" Gap="0.5rem">
+                                    <RadzenCheckBox @bind-Value=@_schemaLockedChecked Name="SchemaLocked" />
+                                    <RadzenLabel Text="Schema Locked" Component="SchemaLocked" />
+                                </RadzenStack>
+                            </RadzenColumn>
+                        </RadzenRow>
+
+                        <!-- Expandable Advanced Section -->
+                        <RadzenPanel Text="Advanced Settings" AllowCollapse="true" Collapsed="true">
+                            <RadzenStack Gap="1rem">
+                                <RadzenRow>
+                                    <RadzenColumn Size="4">
+                                        <RadzenStack Orientation="Orientation.Horizontal" AlignItems="AlignItems.Center" Gap="0.5rem">
+                                            <RadzenCheckBox @bind-Value=@_transactionPersistentChecked Name="TransactionPersistent" />
+                                            <RadzenLabel Text="Transaction Persistent" Component="TransactionPersistent" />
+                                        </RadzenStack>
+                                    </RadzenColumn>
+                                    <RadzenColumn Size="4">
+                                        <RadzenStack Orientation="Orientation.Horizontal" AlignItems="AlignItems.Center" Gap="0.5rem">
+                                            <RadzenCheckBox @bind-Value=@_fastForwardChecked Name="FastForward" />
+                                            <RadzenLabel Text="Fast Forward" Component="FastForward" />
+                                        </RadzenStack>
+                                    </RadzenColumn>
+                                    <RadzenColumn Size="4">
+                                        <RadzenStack Orientation="Orientation.Horizontal" AlignItems="AlignItems.Center" Gap="0.5rem">
+                                            <RadzenCheckBox @bind-Value=@_frontendChecked Name="Frontend" />
+                                            <RadzenLabel Text="Frontend" Component="Frontend" />
+                                        </RadzenStack>
+                                    </RadzenColumn>
+                                </RadzenRow>
+
+                                <RadzenRow>
+                                    <RadzenColumn Size="6">
+                                        <RadzenStack>
+                                            <RadzenLabel Text="Backend" />
+                                            <RadzenNumeric @bind-Value=@_mysqlUser.Backend Name="@nameof(MysqlUserModel.Backend)" Min="0" Max="1" />
+                                        </RadzenStack>
+                                    </RadzenColumn>
+                                </RadzenRow>
+
+                                <RadzenRow>
+                                    <RadzenColumn Size="12">
+                                        <RadzenStack>
+                                            <RadzenLabel Text="Attributes" />
+                                            <RadzenTextBox @bind-Value=@_mysqlUser.Attributes Name="@nameof(MysqlUserModel.Attributes)" />
+                                        </RadzenStack>
+                                    </RadzenColumn>
+                                </RadzenRow>
+
+                                <RadzenRow>
+                                    <RadzenColumn Size="12">
+                                        <RadzenStack>
+                                            <RadzenLabel Text="Comment" />
+                                            <RadzenTextArea @bind-Value=@_mysqlUser.Comment Name="@nameof(MysqlUserModel.Comment)" />
+                                        </RadzenStack>
+                                    </RadzenColumn>
+                                </RadzenRow>
+                            </RadzenStack>
+                        </RadzenPanel>
+
+                        <RadzenStack Orientation="Orientation.Horizontal" JustifyContent="JustifyContent.End" Gap="1rem">
+                            <RadzenButton ButtonType="ButtonType.Submit" Text="Save" ButtonStyle="ButtonStyle.Primary" />
+                            <RadzenButton Text="Cancel" ButtonStyle="ButtonStyle.Light" Click=@OnCancel />
+                        </RadzenStack>
+                    </RadzenStack>
+                </RadzenCard>
+            </RadzenTemplateForm>
+        }
+    </RadzenStack>
+</RadzenContent>
+
+@code {
+    private MysqlUserModel _mysqlUser = new()
+    {
+        Active = 1,
+        UseSsl = 0,
+        DefaultHostgroup = 0,
+        SchemaLocked = 0,
+        TransactionPersistent = 1,
+        FastForward = 0,
+        Backend = 1,
+        Frontend = 1,
+        MaxConnections = 10000,
+        Attributes = string.Empty,
+        Comment = string.Empty
+    };
+
+    // Checkbox bindings for boolean-like integer fields
+    private bool _activeChecked
+    {
+        get => _mysqlUser.Active == 1;
+        set => _mysqlUser.Active = value ? 1 : 0;
+    }
+
+    private bool _useSslChecked
+    {
+        get => _mysqlUser.UseSsl == 1;
+        set => _mysqlUser.UseSsl = value ? 1 : 0;
+    }
+
+    private bool _schemaLockedChecked
+    {
+        get => _mysqlUser.SchemaLocked == 1;
+        set => _mysqlUser.SchemaLocked = value ? 1 : 0;
+    }
+
+    private bool _transactionPersistentChecked
+    {
+        get => _mysqlUser.TransactionPersistent == 1;
+        set => _mysqlUser.TransactionPersistent = value ? 1 : 0;
+    }
+
+    private bool _fastForwardChecked
+    {
+        get => _mysqlUser.FastForward == 1;
+        set => _mysqlUser.FastForward = value ? 1 : 0;
+    }
+
+    private bool _frontendChecked
+    {
+        get => _mysqlUser.Frontend == 1;
+        set => _mysqlUser.Frontend = value ? 1 : 0;
+    }
+
+    private async Task OnSubmit()
+    {
+        try
+        {
+            await ProxySqlRepository.AddMySqlUser(_mysqlUser);
+            NotificationService.Notify(NotificationSeverity.Success, "Success", "MySQL user added successfully");
+            DialogService.Close(true);
+        }
+        catch (Exception ex)
+        {
+            NotificationService.Notify(NotificationSeverity.Error, "Error", "Failed to add MySQL user: " + ex.Message);
+        }
+    }
+
+    private void OnCancel()
+    {
+        DialogService.Close(false);
+    }
+}

--- a/ProxysqlAdminUi.Web/Components/Pages/MySql/Users/DeleteMysqlUserDialog.razor
+++ b/ProxysqlAdminUi.Web/Components/Pages/MySql/Users/DeleteMysqlUserDialog.razor
@@ -1,0 +1,116 @@
+@using ProxysqlAdminUi.Web.Models
+@using ProxysqlAdminUi.Web.Repositories
+
+@attribute [Authorize]
+
+@inject ProxySqlRepository ProxySqlRepository
+@inject DialogService DialogService
+@inject NotificationService NotificationService
+
+<RadzenContent Container="main">
+    <div class="row justify-content-center">
+        <div class="col-md-6">
+            <RadzenTemplateForm TItem="MysqlUserModel" Data=@mysqlUser Submit=@OnConfirmDelete>
+                <RadzenCard>
+                    <div class="row">
+                        <div class="col">
+                            <h3 class="h5">Confirm Delete</h3>
+                            <div class="row mb-3">
+                                <div class="col">
+                                    <p>Are you sure you want to delete MySQL user <strong>@Username</strong>?</p>
+                                    @if (mysqlUser != null)
+                                    {
+                                        <div class="alert alert-info">
+                                            <strong>User Details:</strong><br />
+                                            Username: @mysqlUser.Username<br />
+                                            Default Hostgroup: @mysqlUser.DefaultHostgroup<br />
+                                            Default Schema: @mysqlUser.DefaultSchema<br />
+                                            Active: @(mysqlUser.Active == 1 ? "Yes" : "No")<br />
+                                            Use SSL: @(mysqlUser.UseSsl == 1 ? "Yes" : "No")<br />
+                                            Max Connections: @mysqlUser.MaxConnections<br />
+                                            Backend: @mysqlUser.Backend<br />
+                                            Frontend: @mysqlUser.Frontend
+                                        </div>
+                                        <div class="alert alert-warning">
+                                            <strong>Warning:</strong> This will delete all entries for this username in the mysql_users table.
+                                        </div>
+                                    }
+                                </div>
+                            </div>
+                            <div class="row">
+                                <div class="col d-flex justify-content-end gap-2">
+                                    <RadzenButton ButtonType="ButtonType.Submit"
+                                                Icon="delete"
+                                                Text="Delete"
+                                                ButtonStyle="ButtonStyle.Danger" />
+                                    <RadzenButton ButtonType="ButtonType.Button"
+                                                Icon="cancel"
+                                                Text="Cancel"
+                                                ButtonStyle="ButtonStyle.Light"
+                                                Click=@OnCancel />
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                </RadzenCard>
+            </RadzenTemplateForm>
+        </div>
+    </div>
+</RadzenContent>
+
+@code {
+    [Parameter]
+    public string Username { get; set; }
+
+    [Parameter]
+    public int Backend { get; set; }
+
+    private MysqlUserModel mysqlUser;
+    private bool isLoading = true;
+
+    protected override async Task OnInitializedAsync()
+    {
+        try
+        {
+            var users = await ProxySqlRepository.GetMySqlUsers();
+            mysqlUser = users.FirstOrDefault(u => u.Username == Username && u.Backend == Backend);
+
+            if (mysqlUser == null)
+            {
+                NotificationService.Notify(NotificationSeverity.Error, "Error", "MySQL user not found");
+                DialogService.Close();
+            }
+        }
+        catch (Exception ex)
+        {
+            NotificationService.Notify(NotificationSeverity.Error, "Error", "Failed to load MySQL user details.\r\n" + ex.Message);
+            DialogService.Close();
+        }
+        finally
+        {
+            isLoading = false;
+        }
+    }
+
+    private async Task OnConfirmDelete()
+    {
+        try
+        {
+            await ProxySqlRepository.DeleteMySqlUser(Username);
+
+            NotificationService.Notify(NotificationSeverity.Success, "Success",
+                $"MySQL user '{Username}' has been deleted.");
+            DialogService.Close();
+        }
+        catch (Exception ex)
+        {
+            NotificationService.Notify(NotificationSeverity.Error, "Error",
+                "Failed to delete MySQL user.\r\n" + ex.Message);
+        }
+    }
+
+    private void OnCancel()
+    {
+        DialogService.Close();
+    }
+}

--- a/ProxysqlAdminUi.Web/Components/Pages/MySql/Users/EditMysqlUserDialog.razor
+++ b/ProxysqlAdminUi.Web/Components/Pages/MySql/Users/EditMysqlUserDialog.razor
@@ -1,0 +1,231 @@
+@using ProxysqlAdminUi.Web.Models
+@using ProxysqlAdminUi.Web.Repositories
+
+@attribute [Authorize]
+
+@inject DialogService DialogService
+@inject NotificationService NotificationService
+@inject ProxySqlRepository ProxySqlRepository
+
+<RadzenContent Container="main">
+    <RadzenStack Gap="1rem">
+        @if (_mysqlUser != null)
+        {
+            <RadzenTemplateForm TItem="MysqlUserModel" Data=@_mysqlUser Submit=@OnSubmit>
+                <RadzenCard>
+                    <RadzenStack Gap="1rem">
+                        <!-- Basic Properties -->
+                        <RadzenRow>
+                            <RadzenColumn Size="12">
+                                <RadzenStack>
+                                    <RadzenLabel Text="Username" />
+                                    <RadzenTextBox Value=@_mysqlUser.Username Disabled="true" />
+                                    <RadzenText TextStyle="TextStyle.Caption">Username cannot be changed</RadzenText>
+                                </RadzenStack>
+                            </RadzenColumn>
+                        </RadzenRow>
+
+                        <RadzenRow>
+                            <RadzenColumn Size="12">
+                                <RadzenStack>
+                                    <RadzenLabel Text="Password" />
+                                    <RadzenPassword @bind-Value=@_mysqlUser.Password Name="@nameof(MysqlUserModel.Password)" />
+                                </RadzenStack>
+                            </RadzenColumn>
+                        </RadzenRow>
+
+                        <RadzenRow>
+                            <RadzenColumn Size="6">
+                                <RadzenStack>
+                                    <RadzenLabel Text="Default Hostgroup" />
+                                    <RadzenNumeric @bind-Value=@_mysqlUser.DefaultHostgroup Name="@nameof(MysqlUserModel.DefaultHostgroup)" Min="0" />
+                                </RadzenStack>
+                            </RadzenColumn>
+                            <RadzenColumn Size="6">
+                                <RadzenStack>
+                                    <RadzenLabel Text="Max Connections" />
+                                    <RadzenNumeric @bind-Value=@_mysqlUser.MaxConnections Name="@nameof(MysqlUserModel.MaxConnections)" Min="0" />
+                                </RadzenStack>
+                            </RadzenColumn>
+                        </RadzenRow>
+
+                        <RadzenRow>
+                            <RadzenColumn Size="12">
+                                <RadzenStack>
+                                    <RadzenLabel Text="Default Schema" />
+                                    <RadzenTextBox @bind-Value=@_mysqlUser.DefaultSchema Name="@nameof(MysqlUserModel.DefaultSchema)" />
+                                </RadzenStack>
+                            </RadzenColumn>
+                        </RadzenRow>
+
+                        <RadzenRow>
+                            <RadzenColumn Size="4">
+                                <RadzenStack Orientation="Orientation.Horizontal" AlignItems="AlignItems.Center" Gap="0.5rem">
+                                    <RadzenCheckBox @bind-Value=@_activeChecked Name="Active" />
+                                    <RadzenLabel Text="Active" Component="Active" />
+                                </RadzenStack>
+                            </RadzenColumn>
+                            <RadzenColumn Size="4">
+                                <RadzenStack Orientation="Orientation.Horizontal" AlignItems="AlignItems.Center" Gap="0.5rem">
+                                    <RadzenCheckBox @bind-Value=@_useSslChecked Name="UseSsl" />
+                                    <RadzenLabel Text="Use SSL" Component="UseSsl" />
+                                </RadzenStack>
+                            </RadzenColumn>
+                            <RadzenColumn Size="4">
+                                <RadzenStack Orientation="Orientation.Horizontal" AlignItems="AlignItems.Center" Gap="0.5rem">
+                                    <RadzenCheckBox @bind-Value=@_schemaLockedChecked Name="SchemaLocked" />
+                                    <RadzenLabel Text="Schema Locked" Component="SchemaLocked" />
+                                </RadzenStack>
+                            </RadzenColumn>
+                        </RadzenRow>
+
+                        <!-- Expandable Advanced Section -->
+                        <RadzenPanel Text="Advanced Settings" AllowCollapse="true" Collapsed="true">
+                            <RadzenStack Gap="1rem">
+                                <RadzenRow>
+                                    <RadzenColumn Size="4">
+                                        <RadzenStack Orientation="Orientation.Horizontal" AlignItems="AlignItems.Center" Gap="0.5rem">
+                                            <RadzenCheckBox @bind-Value=@_transactionPersistentChecked Name="TransactionPersistent" />
+                                            <RadzenLabel Text="Transaction Persistent" Component="TransactionPersistent" />
+                                        </RadzenStack>
+                                    </RadzenColumn>
+                                    <RadzenColumn Size="4">
+                                        <RadzenStack Orientation="Orientation.Horizontal" AlignItems="AlignItems.Center" Gap="0.5rem">
+                                            <RadzenCheckBox @bind-Value=@_fastForwardChecked Name="FastForward" />
+                                            <RadzenLabel Text="Fast Forward" Component="FastForward" />
+                                        </RadzenStack>
+                                    </RadzenColumn>
+                                    <RadzenColumn Size="4">
+                                        <RadzenStack Orientation="Orientation.Horizontal" AlignItems="AlignItems.Center" Gap="0.5rem">
+                                            <RadzenCheckBox @bind-Value=@_frontendChecked Name="Frontend" />
+                                            <RadzenLabel Text="Frontend" Component="Frontend" />
+                                        </RadzenStack>
+                                    </RadzenColumn>
+                                </RadzenRow>
+
+                                <RadzenRow>
+                                    <RadzenColumn Size="6">
+                                        <RadzenStack>
+                                            <RadzenLabel Text="Backend" />
+                                            <RadzenNumeric Value=@_mysqlUser.Backend Disabled="true" />
+                                            <RadzenText TextStyle="TextStyle.Caption">Backend value cannot be changed (part of primary key)</RadzenText>
+                                        </RadzenStack>
+                                    </RadzenColumn>
+                                </RadzenRow>
+
+                                <RadzenRow>
+                                    <RadzenColumn Size="12">
+                                        <RadzenStack>
+                                            <RadzenLabel Text="Attributes" />
+                                            <RadzenTextBox @bind-Value=@_mysqlUser.Attributes Name="@nameof(MysqlUserModel.Attributes)" />
+                                        </RadzenStack>
+                                    </RadzenColumn>
+                                </RadzenRow>
+
+                                <RadzenRow>
+                                    <RadzenColumn Size="12">
+                                        <RadzenStack>
+                                            <RadzenLabel Text="Comment" />
+                                            <RadzenTextArea @bind-Value=@_mysqlUser.Comment Name="@nameof(MysqlUserModel.Comment)" />
+                                        </RadzenStack>
+                                    </RadzenColumn>
+                                </RadzenRow>
+                            </RadzenStack>
+                        </RadzenPanel>
+
+                        <RadzenStack Orientation="Orientation.Horizontal" JustifyContent="JustifyContent.End" Gap="1rem">
+                            <RadzenButton ButtonType="ButtonType.Submit" Text="Save" ButtonStyle="ButtonStyle.Primary" />
+                            <RadzenButton Text="Cancel" ButtonStyle="ButtonStyle.Light" Click=@OnCancel />
+                        </RadzenStack>
+                    </RadzenStack>
+                </RadzenCard>
+            </RadzenTemplateForm>
+        }
+    </RadzenStack>
+</RadzenContent>
+
+@code {
+    [Parameter]
+    public string Username { get; set; }
+
+    [Parameter]
+    public int Backend { get; set; }
+
+    private MysqlUserModel _mysqlUser;
+
+    // Checkbox bindings for boolean-like integer fields
+    private bool _activeChecked
+    {
+        get => _mysqlUser?.Active == 1;
+        set { if (_mysqlUser != null) _mysqlUser.Active = value ? 1 : 0; }
+    }
+
+    private bool _useSslChecked
+    {
+        get => _mysqlUser?.UseSsl == 1;
+        set { if (_mysqlUser != null) _mysqlUser.UseSsl = value ? 1 : 0; }
+    }
+
+    private bool _schemaLockedChecked
+    {
+        get => _mysqlUser?.SchemaLocked == 1;
+        set { if (_mysqlUser != null) _mysqlUser.SchemaLocked = value ? 1 : 0; }
+    }
+
+    private bool _transactionPersistentChecked
+    {
+        get => _mysqlUser?.TransactionPersistent == 1;
+        set { if (_mysqlUser != null) _mysqlUser.TransactionPersistent = value ? 1 : 0; }
+    }
+
+    private bool _fastForwardChecked
+    {
+        get => _mysqlUser?.FastForward == 1;
+        set { if (_mysqlUser != null) _mysqlUser.FastForward = value ? 1 : 0; }
+    }
+
+    private bool _frontendChecked
+    {
+        get => _mysqlUser?.Frontend == 1;
+        set { if (_mysqlUser != null) _mysqlUser.Frontend = value ? 1 : 0; }
+    }
+
+    protected override async Task OnInitializedAsync()
+    {
+        try
+        {
+            var users = await ProxySqlRepository.GetMySqlUsers();
+            _mysqlUser = users.FirstOrDefault(u => u.Username == Username && u.Backend == Backend);
+
+            if (_mysqlUser == null)
+            {
+                NotificationService.Notify(NotificationSeverity.Error, "Error", "MySQL user not found");
+                DialogService.Close();
+            }
+        }
+        catch (Exception ex)
+        {
+            NotificationService.Notify(NotificationSeverity.Error, "Error", "Failed to load MySQL user: " + ex.Message);
+            DialogService.Close();
+        }
+    }
+
+    private async Task OnSubmit()
+    {
+        try
+        {
+            await ProxySqlRepository.UpdateMySqlUser(_mysqlUser);
+            NotificationService.Notify(NotificationSeverity.Success, "Success", "MySQL user updated successfully");
+            DialogService.Close(true);
+        }
+        catch (Exception ex)
+        {
+            NotificationService.Notify(NotificationSeverity.Error, "Error", "Failed to update MySQL user: " + ex.Message);
+        }
+    }
+
+    private void OnCancel()
+    {
+        DialogService.Close(false);
+    }
+}

--- a/ProxysqlAdminUi.Web/Components/Pages/MySql/Users/MysqlUsersPage.razor
+++ b/ProxysqlAdminUi.Web/Components/Pages/MySql/Users/MysqlUsersPage.razor
@@ -6,17 +6,40 @@
 @attribute [Authorize]
 
 @inject ProxySqlRepository ProxySqlRepository
+@inject DialogService DialogService
 
-<h3>Users</h3>
+<RadzenRow AlignItems="AlignItems.Normal" Gap="">
+    <RadzenColumn Order="1" Size="3">
+        <RadzenText Text="MySQL Users" TextStyle="TextStyle.DisplayH3" TextAlign="TextAlign.Left" />
+    </RadzenColumn>
+    <RadzenColumn Order="10" Size="3" Offset="6">
+        <RadzenStack Orientation="Orientation.Horizontal" JustifyContent="JustifyContent.End" Gap="1rem">
+            <RadzenButton Icon="refresh" ButtonStyle="ButtonStyle.Light" Text="Refresh" Click="RefreshUsers" />
+            <RadzenButton Icon="add" ButtonStyle="ButtonStyle.Primary" Text="Add User" Click="CreateNewUser" />
+        </RadzenStack>
+    </RadzenColumn>
+</RadzenRow>
 
 <RadzenDataGrid TItem="MysqlUserModel" Data="@MySqlUsersList" AllowPaging="true" PageSize="10">
     <Columns>
         <RadzenDataGridColumn Property="@nameof(MysqlUserModel.Username)" Title="Username" />
         <RadzenDataGridColumn Property="@nameof(MysqlUserModel.DefaultHostgroup)" Title="Default Hostgroup" />
-        <RadzenDataGridColumn>
-            <Template>
-                <RadzenButton Click="@ShowEditModal" Text="Edit" Icon="Edit"></RadzenButton>
-                <RadzenButton Click="@ShowDeleteModal" Text="Delete" Icon="Delete"></RadzenButton>
+        <RadzenDataGridColumn Property="@nameof(MysqlUserModel.DefaultSchema)" Title="Default Schema" />
+        <RadzenDataGridColumn Title="Active">
+            <Template Context="user">
+                @(user.Active == 1 ? "Yes" : "No")
+            </Template>
+        </RadzenDataGridColumn>
+        <RadzenDataGridColumn Title="Use SSL">
+            <Template Context="user">
+                @(user.UseSsl == 1 ? "Yes" : "No")
+            </Template>
+        </RadzenDataGridColumn>
+        <RadzenDataGridColumn Property="@nameof(MysqlUserModel.MaxConnections)" Title="Max Connections" />
+        <RadzenDataGridColumn Title="Actions">
+            <Template Context="user">
+                <RadzenButton Click="@(() => ShowEditModal(user.Username, user.Backend))" Text="Edit" Icon="edit" ButtonStyle="ButtonStyle.Primary" Size="ButtonSize.Small"></RadzenButton>
+                <RadzenButton Click="@(() => ShowDeleteModal(user.Username, user.Backend))" Text="Delete" Icon="delete" ButtonStyle="ButtonStyle.Danger" Size="ButtonSize.Small"></RadzenButton>
             </Template>
         </RadzenDataGridColumn>
     </Columns>
@@ -38,13 +61,55 @@
         return await ProxySqlRepository.GetMySqlUsers();
     }
 
-    private void ShowEditModal()
+    private async Task RefreshUsers()
     {
-        // Implement edit functionality using the selected MySQL user.
+        MySqlUsersList = (await GetMySqlUsersAsync()).ToList();
+        StateHasChanged();
     }
 
-    private void ShowDeleteModal()
+    private async Task ShowEditModal(string username, int backend)
     {
-        // Implement delete functionality using the selected MySQL user.
+        await DialogService.OpenAsync<EditMysqlUserDialog>($"Edit User: {username}",
+            parameters: new Dictionary<string, object>()
+            {
+                { "Username", username },
+                { "Backend", backend }
+            },
+            options: new DialogOptions() { CloseDialogOnEsc = true });
+
+        // Refresh the users list after edit
+        MySqlUsersList = (await GetMySqlUsersAsync()).ToList();
+        StateHasChanged();
+    }
+
+    private async Task ShowDeleteModal(string username, int backend)
+    {
+        await DialogService.OpenAsync<DeleteMysqlUserDialog>($"Delete User: {username}",
+            parameters: new Dictionary<string, object>()
+            {
+                { "Username", username },
+                { "Backend", backend }
+            },
+            options: new DialogOptions()
+            {
+                CloseDialogOnEsc = true
+            });
+
+        // Refresh the users list after delete
+        MySqlUsersList = (await GetMySqlUsersAsync()).ToList();
+        StateHasChanged();
+    }
+
+    private async Task CreateNewUser()
+    {
+        await DialogService.OpenAsync<AddMysqlUserDialog>("Add MySQL User",
+            options: new DialogOptions()
+            {
+                CloseDialogOnEsc = true,
+            });
+
+        // Refresh the users list after add
+        MySqlUsersList = (await GetMySqlUsersAsync()).ToList();
+        StateHasChanged();
     }
 }

--- a/ProxysqlAdminUi.Web/Repositories/ProxySqlRepository.cs
+++ b/ProxysqlAdminUi.Web/Repositories/ProxySqlRepository.cs
@@ -76,11 +76,11 @@ public class ProxySqlRepository(ProxySqlContext dbContext)
 
     public async Task<MysqlUserModel> AddMySqlUser(MysqlUserModel user)
     {
-        var sql = @"INSERT INTO mysql_users 
+        var sql = @"INSERT INTO mysql_users
             (username, password, active, use_ssl, default_hostgroup, default_schema,
              schema_locked, transaction_persistent, fast_forward, backend, frontend,
              max_connections, attributes, comment)
-            VALUES 
+            VALUES
             ({0}, {1}, {2}, {3}, {4}, {5}, {6}, {7}, {8}, {9}, {10}, {11}, {12}, {13})";
 
         await dbContext.Database.ExecuteSqlRawAsync(sql,
@@ -89,12 +89,14 @@ public class ProxySqlRepository(ProxySqlContext dbContext)
             user.TransactionPersistent, user.FastForward, user.Backend,
             user.Frontend, user.MaxConnections, user.Attributes, user.Comment);
 
+        await LoadUsersToRuntime();
+        await SaveUsersToDisk();
         return user;
     }
 
     public async Task<int> UpdateMySqlUser(MysqlUserModel user)
     {
-        var sql = @"UPDATE mysql_users 
+        var sql = @"UPDATE mysql_users
             SET password = {1}, active = {2}, use_ssl = {3},
                 default_hostgroup = {4}, default_schema = {5},
                 schema_locked = {6}, transaction_persistent = {7},
@@ -102,17 +104,35 @@ public class ProxySqlRepository(ProxySqlContext dbContext)
                 max_connections = {10}, attributes = {11}, comment = {12}
             WHERE username = {0} AND backend = {13}";
 
-        return await dbContext.Database.ExecuteSqlRawAsync(sql,
+        var result = await dbContext.Database.ExecuteSqlRawAsync(sql,
             user.Username, user.Password, user.Active, user.UseSsl,
             user.DefaultHostgroup, user.DefaultSchema, user.SchemaLocked,
             user.TransactionPersistent, user.FastForward, user.Frontend,
             user.MaxConnections, user.Attributes, user.Comment, user.Backend);
+
+        await LoadUsersToRuntime();
+        await SaveUsersToDisk();
+        return result;
     }
 
     public async Task<int> DeleteMySqlUser(string username)
     {
-        return await dbContext.Database.ExecuteSqlRawAsync(
+        var result = await dbContext.Database.ExecuteSqlRawAsync(
             "DELETE FROM mysql_users WHERE username = {0}", username);
+
+        await LoadUsersToRuntime();
+        await SaveUsersToDisk();
+        return result;
+    }
+
+    public async Task LoadUsersToRuntime()
+    {
+        await dbContext.Database.ExecuteSqlRawAsync("LOAD MYSQL USERS TO RUNTIME;");
+    }
+
+    public async Task SaveUsersToDisk()
+    {
+        await dbContext.Database.ExecuteSqlRawAsync("SAVE MYSQL USERS TO DISK;");
     }
 
     // MySQL Query Rules


### PR DESCRIPTION
Implemented complete Create, Read, Update, Delete operations for MySQL users that interact with remote ProxySQL instances.

Changes:
- Added LoadUsersToRuntime() and SaveUsersToDisk() methods to ProxySqlRepository
- Updated AddMySqlUser(), UpdateMySqlUser(), and DeleteMySqlUser() to persist changes to ProxySQL runtime and disk
- Created AddMysqlUserDialog component for adding new MySQL users with form validation
- Created EditMysqlUserDialog component for editing existing users with read-only username/backend fields
- Created DeleteMysqlUserDialog component with confirmation prompt and user details display
- Updated MysqlUsersPage.razor with:
  - Add User button and Refresh button in header
  - Enhanced data grid with additional columns (Active, Use SSL, Max Connections)
  - Integrated dialog services for Add/Edit/Delete operations
  - Auto-refresh user list after CRUD operations

All dialogs follow the established pattern used in Query Rules management and use Radzen Blazor components for consistent UI/UX.